### PR TITLE
Update cache.js

### DIFF
--- a/js/cache.js
+++ b/js/cache.js
@@ -57,15 +57,13 @@ class Cache {
 export class GriddedCache extends Cache {
 	reset() {
 		super.reset();
-		if (canvas.grid.isHex && canvas.grid.grid.columnar)
-		{
-			this.gridWidth = Math.ceil(canvas.dimensions.width / ((3/4) * canvas.grid.w))
+		if (canvas.grid.isHex && canvas.grid.grid.columnar) {
+			this.gridWidth = Math.ceil(canvas.dimensions.width / ((3 / 4) * canvas.grid.w));
 		} else {
 			this.gridWidth = Math.ceil(canvas.dimensions.width / canvas.grid.w);
 		}
-		if (canvas.grid.isHex && !canvas.grid.grid.columnar)
-		{
-			this.gridHeight = Math.ceil(canvas.dimensions.height / ((3/4) * canvas.grid.h))
+		if (canvas.grid.isHex && !canvas.grid.grid.columnar) {
+			this.gridHeight = Math.ceil(canvas.dimensions.height / ((3 / 4) * canvas.grid.h));
 		} else {
 			this.gridHeight = Math.ceil(canvas.dimensions.height / canvas.grid.h);
 		}

--- a/js/cache.js
+++ b/js/cache.js
@@ -57,8 +57,18 @@ class Cache {
 export class GriddedCache extends Cache {
 	reset() {
 		super.reset();
-		this.gridWidth = Math.ceil(canvas.dimensions.width / canvas.grid.w);
-		this.gridHeight = Math.ceil(canvas.dimensions.height / canvas.grid.h);
+		if (canvas.grid.isHex && canvas.grid.grid.columnar)
+		{
+			this.gridWidth = Math.ceil(canvas.dimensions.width / ((3/4) * canvas.grid.w))
+		} else {
+			this.gridWidth = Math.ceil(canvas.dimensions.width / canvas.grid.w);
+		}
+		if (canvas.grid.isHex && !canvas.grid.grid.columnar)
+		{
+			this.gridHeight = Math.ceil(canvas.dimensions.height / ((3/4) * canvas.grid.h))
+		} else {
+			this.gridHeight = Math.ceil(canvas.dimensions.height / canvas.grid.h);
+		}
 	}
 
 	static getSnapPointIndexForTokenData(tokenData) {


### PR DESCRIPTION
Larger griddedcache to account for offset hex packing on hex grids

Makes it stop throwing errors and freaking out if you try to route a token on the bottom or right (depending on the direction of the hexes) 1/4 of a hex map.